### PR TITLE
Drop usage of fs-extra and switch to native fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 import path from 'path';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
+
+async function outputFile (file, data, encoding) {
+	const dir = path.dirname(file);
+	await fs.mkdir(dir, { recursive: true });
+
+	return fs.writeFile(file, data, { encoding });
+}
 
 class SaveResourceToExistingDirectoryPlugin {
 	apply (registerAction) {
@@ -16,7 +23,7 @@ class SaveResourceToExistingDirectoryPlugin {
 		registerAction('saveResource', async ({resource}) => {
 			const filename = path.join(absoluteDirectoryPath, resource.getFilename());
 			const text = resource.getText();
-			await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
+			await outputFile(filename, text, resource.getEncoding());
 			loadedResources.push(resource);
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "url": "https://github.com/website-scraper/website-scraper-existing-directory/issues"
   },
   "homepage": "https://github.com/website-scraper/website-scraper-existing-directory#readme",
-  "dependencies": {
-    "fs-extra": "^11.1.0"
-  },
   "devDependencies": {
     "c8": "^11.0.0",
     "chai": "^6.0.1",

--- a/test/existing-directory-plugin.test.js
+++ b/test/existing-directory-plugin.test.js
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import scrape from 'website-scraper';
-import fs from 'fs-extra';
+import fs from 'fs';
 import ExistingDirectoryPlugin from '../index.js';
 
 describe('Existing Directory Plugin', () => {
 	const directory = './test/directory-for-test';
 	const filename = directory + '/index.html';
 
-	after('remove saved index.html from test directory', () => fs.removeSync(filename));
+	after('remove saved index.html from test directory', () => fs.rmSync(filename, { recursive: true, force: true }));
 
 	it('should save file to existing directory', async () => {
 		const result = await scrape({


### PR DESCRIPTION
Closes #71

`fs-extra` has been dropped in the main [node-website-scraper](https://github.com/website-scraper/node-website-scraper) repo in favor of native `fs` ([#608](https://github.com/website-scraper/node-website-scraper/pull/608)). This applies the same cleanup here — native `fs`/`fs/promises` now covers everything `fs-extra` was used for.

## Changes
- **`index.js`**: replaced `fs.outputFile(...)` with a small `outputFile` helper built on `fs/promises` (`mkdir({ recursive: true })` + `writeFile`), mirroring `lib/utils/fs.js` from node-website-scraper#608. Kept inline since `package.json` `files` only publishes `index.js`.
- **Tests**: switched from `fs-extra` to native `fs`, and `fs.removeSync(...)` → `fs.rmSync(..., { recursive: true, force: true })`.
- **`package.json`**: removed `fs-extra` from `dependencies`.

The lockfile is unchanged because `fs-extra` still resolves identically as a transitive dependency of `website-scraper` (dev/peer dep).

## Verification
- `npm test` → 1 passing
- `npm run eslint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)